### PR TITLE
kernel 4.11.9: needs_free_netdev should be false

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -3654,7 +3654,7 @@ static int rtw_cfg80211_add_monitor_if(_adapter *padapter, char *name, struct ne
 	strncpy(mon_ndev->name, name, IFNAMSIZ);
 	mon_ndev->name[IFNAMSIZ - 1] = 0;
 #if (LINUX_VERSION_CODE>=KERNEL_VERSION(4,11,9))
-	mon_ndev->needs_free_netdev = true;
+	mon_ndev->needs_free_netdev = false;
 	mon_ndev->priv_destructor = rtw_ndev_destructor;
 #else
  	mon_ndev->destructor = rtw_ndev_destructor;


### PR DESCRIPTION
See https://github.com/zebulon2/rtl8812au/commit/55280fa97c1383ee53308fd7fc6400b2c6aaaa47#commitcomment-23004680