### PR TITLE
Add support for linux >= 4.20.0

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -330,7 +330,9 @@ static const struct ieee80211_txrx_stypes
 
 static u64 rtw_get_systime_us(void)
 {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 39))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0))
+	return ktime_to_us(ktime_get_boottime());
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 39))
 	struct timespec ts;
 	get_monotonic_boottime(&ts);
 	return ((u64)ts.tv_sec * 1000000) + ts.tv_nsec / 1000;


### PR DESCRIPTION
This module doesn't build on linux 4.20.0 because the function get_monotonic_boottime() is missing,
I replaced it with ktime_to_us(ktime_get_boottime()) which should be equivalent to the way get_monotonic_boottime() was implemented before 4.20.0.