### PR TITLE
get_ds() no more supported - replaced by KERNEL_DS

### DIFF
--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -1976,7 +1976,7 @@ static int isFileReadable(char *path)
 		ret = PTR_ERR(fp);
 	else {
 		oldfs = get_fs();
-		set_fs(get_ds());
+		set_fs(KERNEL_DS);
 
 		if (1 != readFile(fp, &buf, 1))
 			ret = PTR_ERR(fp);
@@ -2006,7 +2006,7 @@ static int retriveFromFile(char *path, u8 *buf, u32 sz)
 			RTW_INFO("%s openFile path:%s fp=%p\n", __FUNCTION__, path , fp);
 
 			oldfs = get_fs();
-			set_fs(get_ds());
+			set_fs(KERNEL_DS);
 			ret = readFile(fp, buf, sz);
 			set_fs(oldfs);
 			closeFile(fp);
@@ -2041,7 +2041,7 @@ static int storeToFile(char *path, u8 *buf, u32 sz)
 			RTW_INFO("%s openFile path:%s fp=%p\n", __FUNCTION__, path , fp);
 
 			oldfs = get_fs();
-			set_fs(get_ds());
+			set_fs(KERNEL_DS);
 			ret = writeFile(fp, buf, sz);
 			set_fs(oldfs);
 			closeFile(fp);


### PR DESCRIPTION
get_ds() was deprecated and seems no more supported since 5.1 kernel. I'm not sure, but I found that it was replaced by KERNEL_DS. Anyway, this seems to fix issue #25. 