### PR TITLE
Kernel 5.2 support

### DIFF
--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1068,7 +1068,7 @@ static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
 	, void *accel_priv
 #endif
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(5, 2, 0))
 	, select_queue_fallback_t fallback
 #endif
 )


### PR DESCRIPTION
I deleted a compilation error for kernel 5.2.
In my situation, this change works well.